### PR TITLE
Enhance task management and persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,7 @@
             <li><button class="nav-btn" data-section="completed"><i class="fas fa-check mr-2"></i> Completed</button></li>
             <li><button class="nav-btn" data-section="dashboard"><i class="fas fa-chart-line mr-2"></i> Dashboard</button></li>
           </ul>
+          <div id="listContainer" class="space-y-2"></div>
           <button class="text-sm text-[#A2D2FF] hover:text-[#FFAFCC] transition-all" onclick="openModal()">
             <i class="fas fa-plus mr-2"></i> Create New List
           </button>
@@ -56,17 +57,35 @@
           </label>
         </div>
       </div>
-      <p class="text-xs text-center text-gray-400 mt-4">Desarrollado por Betzabe Escobar</p>
+      <p class="text-xs text-center text-gray-400 mt-4">Desarrollado por Betzabé Escobar</p>
     </aside>
 
     <!-- Panel principal -->
     <main class="flex-1 p-6 overflow-y-auto" id="mainPanel">
       <!-- Contenido dinámico -->
-      <section id="today" class="hidden"></section>
-      <section id="upcoming" class="hidden"></section>
+      <section id="today" class="hidden">
+        <div class="flex items-center justify-between mb-4">
+          <h2 class="text-xl font-semibold">Tasks for Today</h2>
+          <button id="addTodayTask" class="button-secondary px-3 py-1 rounded-lg text-sm transition-all">
+            <i class="fas fa-plus mr-1"></i> Add Task
+          </button>
+        </div>
+        <ul id="todayList" class="space-y-2"></ul>
+      </section>
+      <section id="upcoming" class="hidden">
+        <p class="text-gray-600">Upcoming tasks will appear here.</p>
+      </section>
       <section id="calendar" class="hidden"></section>
-      <section id="sticky" class="hidden"></section>
-      <section id="completed" class="hidden"></section>
+      <section id="sticky" class="hidden">
+        <button class="button-secondary mb-4" onclick="addStickyNote()">
+          <i class="fas fa-plus mr-1"></i> New Note
+        </button>
+        <div id="stickyWall" class="relative space-y-4"></div>
+      </section>
+      <section id="completed" class="hidden">
+        <h2 class="text-xl font-semibold mb-4">Completed Tasks</h2>
+        <ul id="completedList" class="space-y-2"></ul>
+      </section>
       <section id="dashboard" class="hidden"></section>
       <div id="defaultMessage" class="text-center text-gray-500 italic">Selecciona una sección para comenzar...</div>
     </main>

--- a/inicio.html
+++ b/inicio.html
@@ -88,7 +88,7 @@
 
   <!-- Footer -->
   <footer class="pie">
-    <p>🌸 Hecho con amor por Betzabe • <a href="https://github.com/awkward-3312/To-do-list" target="_blank">GitHub</a></p>
+    <p>🌸 Hecho con amor por Betzabé • <a href="https://github.com/awkward-3312/To-do-list" target="_blank">GitHub</a></p>
   </footer>
 
   <!-- JS -->

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "to-do-list",
+  "version": "1.0.0",
+  "description": "Simple to-do list app",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.6.1"
+  }
+}

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -1,0 +1,33 @@
+const { loadFromLocalStorage, saveToLocalStorage, setData, getData } = require('../js/index.js');
+
+describe('localStorage helpers', () => {
+  beforeEach(() => {
+    global.localStorage = {
+      store: {},
+      getItem(key) { return this.store[key] || null; },
+      setItem(key, value) { this.store[key] = value; },
+      clear() { this.store = {}; }
+    };
+  });
+
+  test('data round trips correctly', () => {
+    const lists = [{ id: 1, name: 'Test', color: '#fff' }];
+    const tasks = { 1: [{ id: 1, title: 'Task', date: '2023-01-01' }] };
+    const notes = [{ id: 1, text: 'Note' }];
+    const today = [{ id: 1, title: 'Today Task', time: '', priority: 'alta' }];
+    const completed = [{ id: 2, title: 'Done', time: '', priority: 'media' }];
+
+    setData(lists, tasks, notes, today, completed);
+    saveToLocalStorage();
+
+    setData([], {}, [], [], []);
+    loadFromLocalStorage();
+
+    const data = getData();
+    expect(data.customLists).toEqual(lists);
+    expect(data.tasksByList).toEqual(tasks);
+    expect(data.stickyNotes).toEqual(notes);
+    expect(data.todayTasks).toEqual(today);
+    expect(data.completedTasks).toEqual(completed);
+  });
+});


### PR DESCRIPTION
## Summary
- add basic sections for today, upcoming, sticky notes and completed tasks
- implement today task functionality with local storage persistence
- render completed tasks and allow restoring them
- expose new helpers for tests and expand storage round-trip test

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840f1931b04832b94f6968575705778